### PR TITLE
Add created_at timestamp to token info

### DIFF
--- a/lib/g5_authentication_client/token_info.rb
+++ b/lib/g5_authentication_client/token_info.rb
@@ -23,5 +23,10 @@ module G5AuthenticationClient
     #   The UID of the OAuth application that requested this token
     property :application_uid, from: :application,
                                type: lambda { |val| (val[:uid] || val['uid']).to_s }
+
+    # @!attribute [rw] created_at
+    #   @return [Time]
+    #   The token creation timestamp
+    property :created_at, type: lambda { |val| Time.at(val.to_i) }
   end
 end

--- a/lib/g5_authentication_client/token_info.rb
+++ b/lib/g5_authentication_client/token_info.rb
@@ -3,6 +3,8 @@ require 'modelish'
 module G5AuthenticationClient
   # G5 Authentication access token info
   class TokenInfo < Modelish::Base
+    ignore_unknown_properties!
+
     # @!attribute [rw] resource_owner_id
     #   @return [String]
     #   The ID of the user that owns the resource

--- a/spec/g5_authentication_client/token_info_spec.rb
+++ b/spec/g5_authentication_client/token_info_spec.rb
@@ -10,7 +10,8 @@ describe G5AuthenticationClient::TokenInfo do
       scopes: scopes,
       expires_in_seconds: expires_in_seconds,
       application: { uid: application_uid },
-      created_at: created_at
+      created_at: created_at,
+      extra_attribute: 'some value'
     }
   end
 
@@ -18,7 +19,7 @@ describe G5AuthenticationClient::TokenInfo do
   let(:scopes) { ['leads','calls'] }
   let(:expires_in_seconds) { '3600' }
   let(:application_uid) { 'application-uid-42' }
-	let(:created_at) { Time.now.to_i }
+  let(:created_at) { Time.now.to_i }
 
   context 'with default initialization' do
     let(:attributes) {}
@@ -42,6 +43,10 @@ describe G5AuthenticationClient::TokenInfo do
     it 'should have nil created_at' do
       expect(token.created_at).to be_nil
     end
+
+    it 'should not have extra_attribute' do
+      expect(token).to_not respond_to(:extra_attribute)
+    end
   end
 
   context 'with full initialization' do
@@ -62,7 +67,11 @@ describe G5AuthenticationClient::TokenInfo do
     end
 
     it 'should have created_at timestamp' do
-			expect(token.created_at).to eq(Time.at(created_at))
+      expect(token.created_at).to eq(Time.at(created_at))
+    end
+
+    it 'should not have extra_attribute' do
+      expect(token).to_not respond_to(:extra_attribute)
     end
   end
 end

--- a/spec/g5_authentication_client/token_info_spec.rb
+++ b/spec/g5_authentication_client/token_info_spec.rb
@@ -9,7 +9,8 @@ describe G5AuthenticationClient::TokenInfo do
       resource_owner_id: resource_owner_id,
       scopes: scopes,
       expires_in_seconds: expires_in_seconds,
-      application: { uid: application_uid }
+      application: { uid: application_uid },
+      created_at: created_at
     }
   end
 
@@ -17,6 +18,7 @@ describe G5AuthenticationClient::TokenInfo do
   let(:scopes) { ['leads','calls'] }
   let(:expires_in_seconds) { '3600' }
   let(:application_uid) { 'application-uid-42' }
+	let(:created_at) { Time.now.to_i }
 
   context 'with default initialization' do
     let(:attributes) {}
@@ -36,6 +38,10 @@ describe G5AuthenticationClient::TokenInfo do
     it 'should have nil application_uid' do
       expect(token.application_uid).to be_nil
     end
+
+    it 'should have nil created_at' do
+      expect(token.created_at).to be_nil
+    end
   end
 
   context 'with full initialization' do
@@ -53,6 +59,10 @@ describe G5AuthenticationClient::TokenInfo do
 
     it 'should have application_uid' do
       expect(token.application_uid).to eq(application_uid)
+    end
+
+    it 'should have created_at timestamp' do
+			expect(token.created_at).to eq(Time.at(created_at))
     end
   end
 end


### PR DESCRIPTION
Upcoming upgrades to the auth server will add a `created_at` timestamp to the response from the `/oauth/token/info` endpoint. Unfortunately, that breaks existing versions of g5_authentication_client. This PR fixes that problem, as well as making `G5AuthenticationClient::TokenInfo` more resilient to change in the future.