### PR TITLE
Handle nil response

### DIFF
--- a/lib/g5_authentication_client/auth_token_helper.rb
+++ b/lib/g5_authentication_client/auth_token_helper.rb
@@ -3,7 +3,7 @@ module G5AuthenticationClient::AuthTokenHelper
   # Yield response should have a 'code' method for the http status code
   def do_with_username_pw_access_token
     response = yield cached_username_pw_access_token
-    if 401 == response.code.to_i
+    if response.nil? || 401 == response.code.to_i
       @cached_username_pw_access_token = nil
       response                         = yield cached_username_pw_access_token
     end

--- a/spec/g5_authentication_client/auth_token_helper_spec.rb
+++ b/spec/g5_authentication_client/auth_token_helper_spec.rb
@@ -37,17 +37,34 @@ describe G5AuthenticationClient::AuthTokenHelper do
       end
     end
 
-    context '401' do
-      let(:code) { '401' }
+    describe 'bad responses' do
       before do
         allow(G5AuthenticationClient::Client).to receive(:new).and_return(double(:client, username_pw_access_token: token))
         call
       end
-      it 'responds with the yielded response' do
-        expect(call).to eq(response)
+
+      context '401' do
+        let(:code) { '401' }
+
+        it 'responds with the yielded response' do
+          expect(call).to eq(response)
+        end
+
+        it 'calls username_pw_access_token once' do
+          expect(G5AuthenticationClient::Client).to have_received(:new).twice
+        end
       end
-      it 'calls username_pw_access_token once' do
-        expect(G5AuthenticationClient::Client).to have_received(:new).twice
+
+      context 'nil response' do
+        let(:response) { nil }
+
+        it 'responds with the yielded response' do
+          expect(call).to eq(response)
+        end
+
+        it 'calls username_pw_access_token once' do
+          expect(G5AuthenticationClient::Client).to have_received(:new).twice
+        end
       end
     end
   end


### PR DESCRIPTION
Handle `nil` response in auth token helper.

https://www.pivotaltracker.com/story/show/137983231
https://app.honeybadger.io/projects/42676/faults/32079081#notice-comments

```Ruby
response = yield cached_username_pw_access_token
response #=> nil
response.code #=> "NoMethodError: undefined method `code' for nil:NilClass"
```